### PR TITLE
設計の問題ページでその他の問題や相談の部分のチャネルが #keybord-zatsu だったのを #easy-question に修正

### DIFF
--- a/docs/src/html/designProblem.html
+++ b/docs/src/html/designProblem.html
@@ -40,7 +40,7 @@
 	        <div class="card border h-100">
 	          <div class="card-body">
 	            <h4 id="otherDesignTitle" class="card-title text-decoration-underline">その他の問題や相談</h4>
-	            <p id="pOtherDesign" class="card-text">上記以外の問題や、上記のどちらに当てはまるか分からない場合は、Discord の Self-Made Keyboards in Japan の #keybord-zatsu チャンネルへ</p>
+	            <p id="pOtherDesign" class="card-text">上記以外の問題や、上記のどちらに当てはまるか分からない場合は、Discord の Self-Made Keyboards in Japan の #easy-question チャンネルへ</p>
 	          </div>
 						<div class="card-footer">
 							<a class="btn btn-primary fs-6 px-2 text-start" href="https://discord.gg/zXCss8T" role="button">


### PR DESCRIPTION
設計の問題ページでその他の問題や相談のボックスの誘導先チャネルが #keybord-zatsu になっていたのでこちらを #easy-question に変更しました。